### PR TITLE
Shell: Allow blanking the screen even if screensaver is up

### DIFF
--- a/gnome-settings-daemon/org.gnome.ScreenSaver.xml
+++ b/gnome-settings-daemon/org.gnome.ScreenSaver.xml
@@ -41,5 +41,6 @@
                 <signal name="ActiveChanged">
                         <arg name="new_value" type="b" />
                 </signal>
+                <signal name="ActiveResumed" />
         </interface>
 </node>

--- a/plugins/power/gsd-power-manager.c
+++ b/plugins/power/gsd-power-manager.c
@@ -2788,6 +2788,14 @@ handle_screensaver_active (GsdPowerManager *manager,
 }
 
 static void
+handle_active_resumed (GsdPowerManager *manager)
+{
+        g_debug ("Received screensaver ActiveResumed signal");
+        if (manager->priv->screensaver_active)
+                idle_set_mode (manager, GSD_POWER_IDLE_MODE_BLANK);
+}
+
+static void
 screensaver_signal_cb (GDBusProxy *proxy,
                        const gchar *sender_name,
                        const gchar *signal_name,
@@ -2796,6 +2804,8 @@ screensaver_signal_cb (GDBusProxy *proxy,
 {
         if (g_strcmp0 (signal_name, "ActiveChanged") == 0)
                 handle_screensaver_active (GSD_POWER_MANAGER (user_data), parameters);
+        else if (g_strcmp0 (signal_name, "ActiveResumed") == 0)
+                handle_active_resumed (GSD_POWER_MANAGER (user_data));
 }
 
 static void


### PR DESCRIPTION
Previously blanking was only done if screensaver was not on the screen
yet but we need this functionality fixed for lock screen events.

[endlessm/eos-shell#1532]