### PR TITLE
Increase blank delay for screensaver

### DIFF
--- a/plugins/power/gsd-power-constants.h
+++ b/plugins/power/gsd-power-constants.h
@@ -19,7 +19,7 @@
  */
 
 /* The blank delay when the screensaver is active */
-#define SCREENSAVER_TIMEOUT_BLANK                       15 /* seconds */
+#define SCREENSAVER_TIMEOUT_BLANK                       30 /* seconds */
 
 /* The dim delay when dimming on idle is requested but idle-delay
  * is set to "Never" */


### PR DESCRIPTION
Upon waking from a screen lock, if the user stops typing,
the password screen is only displayed for 15 seconds.
This can be a bit confusing to users, especially if using
an external display that takes several seconds to wake up.
Let's bump this timeout up to 30 seconds.

[endlessm/eos-shell#5212]