### PR TITLE
mouse: Do not re-enable touchpad on touchpad disable

### DIFF
--- a/plugins/mouse/gsd-mouse-manager.c
+++ b/plugins/mouse/gsd-mouse-manager.c
@@ -1160,7 +1160,8 @@ device_removed_cb (GdkDeviceManager *device_manager,
                 /* If a touchpad was to disappear... */
                 set_disable_w_typing (manager, g_settings_get_boolean (manager->priv->touchpad_settings, KEY_TOUCHPAD_DISABLE_W_TYPING));
 
-                ensure_touchpad_active (manager);
+                if (gdk_device_get_source (device) != GDK_SOURCE_TOUCHPAD)
+                        ensure_touchpad_active (manager);
         }
 }
 


### PR DESCRIPTION
If the user disables the touchpad using the touchpad toggle hotkey we
should honor it instead of re-enabling the touchpad, even if there is
no other type of pointing device present in the system.

Without this patch the situation when using the touchpad toggle hotkey
is as follows:

 * 1st press: OSD "touchpad disabled" shows up, cursor movement is disabled,
   but the touchpad settings are still available under "Mouse & Touchpad" in
   g-c-c.
 * 2nd press: OSD "touchpad disabled" shows up, cursor movement remains
   disabled, and now the touchpad settings are greyed out under "Mouse &
   Touchpad" in g-c-c.
 * 3rd press: OSD "touchpad enabled" shows up, cursor movement is re-enabled
   and touchpad settings are available again under "Mouse & Touchpad" in g-c-c,
   but a new ON|OFF switch is created in the touchpad part of the "Mouse &
   Touchpad" dialog (which was not initially there).

[endlessm/eos-shell#5452]