### PR TITLE
Consider com.endlessm.CompositeMode.text-scaling-factor GSetting if available

### DIFF
--- a/plugins/xsettings/gsd-xsettings-manager.c
+++ b/plugins/xsettings/gsd-xsettings-manager.c
@@ -58,6 +58,7 @@
 #define INTERFACE_SETTINGS_SCHEMA "org.gnome.desktop.interface"
 #define SOUND_SETTINGS_SCHEMA     "org.gnome.desktop.sound"
 #define PRIVACY_SETTINGS_SCHEMA     "org.gnome.desktop.privacy"
+#define COMPOSITE_MODE_SCHEMA     "com.endlessm.CompositeMode"
 
 #define XSETTINGS_PLUGIN_SCHEMA "org.gnome.settings-daemon.plugins.xsettings"
 #define XSETTINGS_OVERRIDE_KEY  "overrides"
@@ -266,6 +267,8 @@ struct GnomeXSettingsManagerPrivate
         GHashTable        *settings;
 
         GSettings         *plugin_settings;
+        GSettings         *composite_settings;
+
         fontconfig_monitor_handle_t *fontconfig_handle;
 
         GsdXSettingsGtk   *gtk;
@@ -432,13 +435,19 @@ get_dpi_from_gsettings (GnomeXSettingsManager *manager)
 	GSettings  *interface_settings;
         double      dpi;
         double      factor;
+        double      composite_factor;
 
 	interface_settings = g_hash_table_lookup (manager->priv->settings, INTERFACE_SETTINGS_SCHEMA);
         factor = g_settings_get_double (interface_settings, TEXT_SCALING_FACTOR_KEY);
 
+        /* The com.endlessm.CompositeMode schema will be present in some configurations only. */
+        composite_factor = manager->priv->composite_settings != NULL
+                ? g_settings_get_double (manager->priv->composite_settings, TEXT_SCALING_FACTOR_KEY)
+                : 1.0;
+
 	dpi = DPI_FALLBACK;
 
-        return dpi * factor;
+        return dpi * factor * composite_factor;
 }
 
 static GnomeRROutput *
@@ -837,6 +846,15 @@ plugin_callback (GSettings             *settings,
 }
 
 static void
+composite_mode_callback (GSettings             *settings,
+                         const char            *key,
+                         GnomeXSettingsManager *manager)
+{
+        update_xft_settings (manager);
+        queue_notify (manager);
+}
+
+static void
 gtk_modules_callback (GsdXSettingsGtk       *gtk,
                       GParamSpec            *spec,
                       GnomeXSettingsManager *manager)
@@ -1177,6 +1195,27 @@ gnome_xsettings_manager_start (GnomeXSettingsManager *manager,
                           G_CALLBACK (gtk_modules_callback), manager);
         gtk_modules_callback (manager->priv->gtk, NULL, manager);
 
+        /* Composite mode settings */
+        GSettingsSchema *composite_schema;
+        composite_schema = g_settings_schema_source_lookup (g_settings_schema_source_get_default (),
+                                                            COMPOSITE_MODE_SCHEMA, FALSE);
+
+        /* The com.endlessm.CompositeMode schema will be present in some configurations only,
+         * so we need to do some checks on startup, before creating and storing the GSettings. */
+        if (composite_schema != NULL) {
+                if (g_settings_schema_has_key (composite_schema, TEXT_SCALING_FACTOR_KEY)) {
+                        manager->priv->composite_settings = g_settings_new (COMPOSITE_MODE_SCHEMA);
+                        g_signal_connect_object (manager->priv->composite_settings, "changed",
+                                                 G_CALLBACK (composite_mode_callback), manager, 0);
+                }
+
+                g_settings_schema_unref (composite_schema);
+        } else {
+                /* This NULL pointer will be used as a flag in get_dpi_from_gsettings()
+                 * to know that the com.endlessm.CompositeMode schema is not available. */
+                manager->priv->composite_settings = NULL;
+        }
+
         /* Xft settings */
         update_xft_settings (manager);
 
@@ -1231,6 +1270,11 @@ gnome_xsettings_manager_stop (GnomeXSettingsManager *manager)
         if (p->plugin_settings != NULL) {
                 g_object_unref (p->plugin_settings);
                 p->plugin_settings = NULL;
+        }
+
+        if (p->composite_settings != NULL) {
+                g_object_unref (p->composite_settings);
+                p->composite_settings = NULL;
         }
 
         stop_fontconfig_monitor (manager);


### PR DESCRIPTION
If the eos-composite-mode package is installed, the com.endlessm.CompositeMode
will be available to provide an additional, accumulative, scaling factor to be
used on top of the one from org.gnome.desktop.interface, so we need to check
it here to determine the right value to set for the global Xft DPI setting.

[endlessm/eos-shell#6197]