### PR TITLE
media-keys: Map LEFT_META+F1 to Help by default

### DIFF
--- a/plugins/media-keys/shortcuts-list.h
+++ b/plugins/media-keys/shortcuts-list.h
@@ -64,6 +64,7 @@ static struct {
         { SCREENSAVER_KEY, "screensaver", NULL, NULL, SCREENSAVER_MODE },
         { SCREENSAVER_KEY, NULL, N_("Lock Screen"), "XF86ScreenSaver", SCREENSAVER_MODE },
         { HELP_KEY, "help", NULL, NULL, GSD_ACTION_MODE_LAUNCHER },
+        { HELP_KEY, NULL, NULL, "<Super>F1", GSD_ACTION_MODE_LAUNCHER },
         { SCREENSHOT_KEY, "screenshot", NULL, NULL, NO_LOCK_MODE },
         { WINDOW_SCREENSHOT_KEY, "window-screenshot", NULL, NULL, NO_LOCK_MODE },
         { AREA_SCREENSHOT_KEY, "area-screenshot", NULL, NULL, NO_LOCK_MODE },


### PR DESCRIPTION
The HP Stream 11 Pro G2 has a media key labeled with a question mark
('?') on F1, which sends a combination of LEFT_META and F1. On Windows
it opens the an UI that says "Getting started", so mapping it to open
the Help Center is a sensible solution.

https://phabricator.endlessm.com/T10958