### PR TITLE
media-keys: add Super+F1 as a hardcoded shortcut for launching Help

### DIFF
--- a/plugins/media-keys/shortcuts-list.h
+++ b/plugins/media-keys/shortcuts-list.h
@@ -128,6 +128,7 @@ static struct {
         { SCREENSAVER_KEY, "screensaver", NULL, NULL, SCREENSAVER_MODE },
         { SCREENSAVER_KEY, NULL, N_("Lock Screen"), "XF86ScreenSaver", SCREENSAVER_MODE },
         { HELP_KEY, "help", NULL, NULL, GSD_KEYBINDING_MODE_LAUNCHER },
+        { HELP_KEY, NULL, NULL, "<Super>F1", GSD_KEYBINDING_MODE_LAUNCHER },
         { SCREENSHOT_KEY, "screenshot", NULL, NULL, SHELL_KEYBINDING_MODE_ALL },
         { WINDOW_SCREENSHOT_KEY, "window-screenshot", NULL, NULL, SHELL_KEYBINDING_MODE_NORMAL },
         { AREA_SCREENSHOT_KEY, "area-screenshot", NULL, NULL, SHELL_KEYBINDING_MODE_ALL },


### PR DESCRIPTION
This is what Windows hardcodes, and some laptops have keyboards with
"help" physical keys that send Super+F1 when pressed.

https://phabricator.endlessm.com/T10958