### PR TITLE
mouse: Change "disable while typing" before state

### DIFF
--- a/plugins/mouse/gsd-mouse-manager.c
+++ b/plugins/mouse/gsd-mouse-manager.c
@@ -1247,6 +1247,9 @@ ensure_touchpad_active (GsdMouseManager *manager)
         gboolean state;
 
         state = get_touchpad_enabled (manager);
+
+        set_disable_w_typing (manager, state);
+
         if (state) {
                 devices = get_disabled_synaptics ();
                 for (l = devices; l != NULL; l = l->next) {
@@ -1275,8 +1278,6 @@ ensure_touchpad_active (GsdMouseManager *manager)
 
                 g_list_free (devices);
         }
-
-        set_disable_w_typing (manager, state);
 }
 
 static void


### PR DESCRIPTION
After the change to use "Synaptics Off" instead of "Device Disable" it
is not possible to disable the touchpad in systems which the
KEY_TOUCHPAD_TOGGLE event arrives through the keyboard input device,
because syndaemon reverts it back to 0.

This is the sequence of changes I see on a Yoga 900 running g-s-d
3.18.3 when I press the touchpad toggle key (on F6):

 - "Synaptics Off" changes to 2, because the function key press is
   considered typing by syndaemon;
 - The touchpad settings panel ON|OFF switch changes to OFF, and
   "Synaptics Off" changes to 1, to react to the KEY_F21 (touchpad
   toggle) event sent through the input device;
 - "Synaptics Off" changes to 0, because 1 second has passed since the
   last keystroke. The touchpad settings panel ON|OFF switch does not
   change back to ON.
 - On a 2nd press of the touchpad toogle function key, the touchpad
   settings panel ON|OFF switch changes to ON and no "Synaptics Off"
   changes are observed.

Simply chaging the order between changing the "Synaptics Off" property
and setting "disable while typing" in ensure_touchpad_active fixes this
problem.

https://bugzilla.gnome.org/show_bug.cgi?id=747504
https://phabricator.endlessm.com/T11380