### PR TITLE
T11500: Ignore touchpad-toggle if lid is closed

### DIFF
--- a/plugins/media-keys/gsd-media-keys-manager.c
+++ b/plugins/media-keys/gsd-media-keys-manager.c
@@ -195,6 +195,9 @@ struct GsdMediaKeysManagerPrivate
         GDBusProxy      *logind_proxy;
         gint             inhibit_keys_fd;
 
+        /* UPower stuff */
+        UpClient                *up_client;
+
         GList           *media_players;
 
         GDBusNodeInfo   *introspection_data;
@@ -940,6 +943,12 @@ do_touchpad_action (GsdMediaKeysManager *manager)
 {
         GSettings *settings;
         gboolean state;
+
+        if (up_client_get_lid_is_present (manager->priv->up_client) &&
+            up_client_get_lid_is_closed (manager->priv->up_client)) {
+                g_debug ("lid is currently closed, ignoring touchpad-toggle media key");
+                return;
+        }
 
         if (touchpad_is_present () == FALSE) {
                 do_touchpad_osd_action (manager, FALSE);
@@ -2707,6 +2716,7 @@ gsd_media_keys_manager_stop (GsdMediaKeysManager *manager)
         g_clear_object (&priv->power_proxy);
         g_clear_object (&priv->power_screen_proxy);
         g_clear_object (&priv->power_keyboard_proxy);
+        g_clear_object (&priv->up_client);
         g_clear_object (&priv->composite_device);
         g_clear_object (&priv->mpris_controller);
         g_clear_object (&priv->screencast_proxy);
@@ -2947,7 +2957,6 @@ on_bus_gotten (GObject             *source_object,
 {
         GDBusConnection *connection;
         GError *error = NULL;
-        UpClient *up_client;
 
         connection = g_bus_get_finish (res, &error);
         if (connection == NULL) {
@@ -3006,9 +3015,8 @@ on_bus_gotten (GObject             *source_object,
                           (GAsyncReadyCallback) power_keyboard_ready_cb,
                           manager);
 
-        up_client = up_client_new ();
-        manager->priv->composite_device = up_client_get_display_device (up_client);
-        g_object_unref (up_client);
+        manager->priv->up_client = up_client_new ();
+        manager->priv->composite_device = up_client_get_display_device (manager->priv->up_client);
 }
 
 static void


### PR DESCRIPTION
On the Lenovo Yoga 900 a touchpad-toggle event is generated when the lid
is closed, so when the lid is re-opened the touchpad enable state is
reversed. Ignoring a touchpad-toggle event when the lid is closed avoids
this behavior.

https://phabricator.endlessm.com/T11500