### PR TITLE
media-keys: Increase the touchpad-toggle ignore timer

### DIFF
--- a/plugins/media-keys/gsd-media-keys-manager.c
+++ b/plugins/media-keys/gsd-media-keys-manager.c
@@ -3173,7 +3173,7 @@ lid_state_changed_cb (UpClient *client, GParamSpec *pspec, GsdMediaKeysManager *
                 if (manager->priv->inhibit_tp_toggle_timer_id != 0)
                         return;
                 manager->priv->inhibit_tp_toggle_timer_id =
-                        g_timeout_add_seconds (2, (GSourceFunc) lid_opened,
+                        g_timeout_add_seconds (5, (GSourceFunc) lid_opened,
                                                manager);
         } else {
                 g_debug ("lid is now closed");


### PR DESCRIPTION
Ignoring the touchpad-toggle key event for 2s has helped, but the
problem still occurs ocasionally. Let's increase the timeout for 5s.

https://phabricator.endlessm.com/T11500