### PR TITLE
fontconfig-monitor: do not recreate configuration every event

### DIFF
--- a/plugins/xsettings/fontconfig-monitor.c
+++ b/plugins/xsettings/fontconfig-monitor.c
@@ -103,10 +103,17 @@ static void
 stuff_changed (GFileMonitor *monitor G_GNUC_UNUSED,
                GFile *file G_GNUC_UNUSED,
                GFile *other_file G_GNUC_UNUSED,
-               GFileMonitorEvent event_type G_GNUC_UNUSED,
+               GFileMonitorEvent event_type,
                gpointer data)
 {
         fontconfig_monitor_handle_t *handle = data;
+
+        /* Wait for G_FILE_MONITOR_EVENT_CHANGES_DONE_HINT before notifying
+         * fontconfig.
+         */
+        if (event_type == G_FILE_MONITOR_EVENT_CHANGED ||
+            event_type == G_FILE_MONITOR_EVENT_CREATED)
+                return;
 
         gboolean notify = FALSE;
 


### PR DESCRIPTION
Currently, the fontconfig monitor will call FcInitReinitialize() for
every event triggered by the file monitor on the fontconfig
configuration directories.

For large font files this creates a situation where the configuration is
reinitialized before the file has been fully copied and available for
use in fontconfig. The result is that the cache mtime for that directory
will be updated to use the current modification time, with the new font
file not registered in the cache yet, preventing the new font to be
avaialble to applications until the fontconfig cache is forcefully
recreated.

We can fix this by ignoring CREATED and CHANGED events from the file
monitor; in both those cases we will receive a CHANGES_DONE_HINT event
when the file is completely copied in the directory.

https://phabricator.endlessm.com/T13909