### PR TITLE
Also consider 'Discovered' printers as remote printers for notifications

### DIFF
--- a/plugins/print-notifications/gsd-print-notifications-manager.c
+++ b/plugins/print-notifications/gsd-print-notifications-manager.c
@@ -165,7 +165,7 @@ is_local_dest (const char  *name,
         }
 
         type = atoi (type_str);
-        is_remote = type & (CUPS_PRINTER_REMOTE | CUPS_PRINTER_IMPLICIT);
+        is_remote = type & (CUPS_PRINTER_REMOTE | CUPS_PRINTER_IMPLICIT | CUPS_PRINTER_DISCOVERED);
         g_free (type_str);
  out:
         return !is_remote;


### PR DESCRIPTION
This is an attempt to reduce the 'chatty-ness' of desktop notifications when
joining a network with publicly shared printers that get automatically added.

https://phabricator.endlessm.com/T19323