### PR TITLE
Revert "Also consider 'Discovered' printers as remote printers for notifications"

### DIFF
--- a/plugins/print-notifications/gsd-print-notifications-manager.c
+++ b/plugins/print-notifications/gsd-print-notifications-manager.c
@@ -165,7 +165,7 @@ is_local_dest (const char  *name,
         }
 
         type = atoi (type_str);
-        is_remote = type & (CUPS_PRINTER_REMOTE | CUPS_PRINTER_IMPLICIT | CUPS_PRINTER_DISCOVERED);
+        is_remote = type & (CUPS_PRINTER_REMOTE | CUPS_PRINTER_IMPLICIT);
         g_free (type_str);
  out:
         return !is_remote;


### PR DESCRIPTION
This turned out not to be the right fix, the problem was that we had a too
old version of cups-browsed that was causing that CUPS did not set the
CUPS_PRINTER_REMOTE flag for the discovered printers. Upgrading to a
newer version of cups-filters fixed the problem.

This reverts commit 9b698b83a39e2c00016951b02dad23a47da7aa48.

https://phabricator.endlessm.com/T19323