### PR TITLE
Revert "media-keys: Disable rfkill keys handling"

### DIFF
--- a/plugins/media-keys/shortcuts-list.h
+++ b/plugins/media-keys/shortcuts-list.h
@@ -108,12 +108,9 @@ static struct {
         { KEYBOARD_BRIGHTNESS_DOWN_KEY, NULL, N_("Keyboard Brightness Down"), "XF86KbdBrightnessDown", SHELL_ACTION_MODE_ALL },
         { KEYBOARD_BRIGHTNESS_TOGGLE_KEY, NULL, N_("Keyboard Brightness Toggle"), "XF86KbdLightOnOff", SHELL_ACTION_MODE_ALL },
         { BATTERY_KEY, NULL, N_("Battery Status"), "XF86Battery", GSD_ACTION_MODE_LAUNCHER },
-        /* FIXME: https://bugzilla.gnome.org/show_bug.cgi?id=760517 */
-#if 0
         { RFKILL_KEY, NULL, N_("Toggle Airplane Mode"), "XF86WLAN", GSD_ACTION_MODE_LAUNCHER },
         { RFKILL_KEY, NULL, N_("Toggle Airplane Mode"), "XF86UWB", GSD_ACTION_MODE_LAUNCHER },
         { BLUETOOTH_RFKILL_KEY, NULL, N_("Toggle Bluetooth"), "XF86Bluetooth", GSD_ACTION_MODE_LAUNCHER }
-#endif
 };
 
 #undef SCREENSAVER_MODE


### PR DESCRIPTION
This reverts commit 858346b784ee986ef536b68827959105fea84460.

On some Acer Aspire laptops (ES1-432, E5-575, E5-523G, A315-21) this
change breaks the airplane-mode media key, as the RFKill input handler
does not work there.

We will investigate the problem in rfkill-input, but for now lets revert
this commit to avoid user-visible regressions.

https://phabricator.endlessm.com/T19631