### PR TITLE
power: Use xrandr backlight control for nvidia driver

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -250,6 +250,8 @@ PKG_CHECK_MODULES(XRANDR,
 		  gnome-desktop-3.0 >= $GNOME_DESKTOP_REQUIRED_VERSION
 		  upower-glib >= $UPOWER_REQUIRED_VERSION)
 
+PKG_CHECK_MODULES(XRANDR_REAL, xrandr)
+
 dnl ---------------------------------------------------------------------------
 dnl - XTest
 dnl ---------------------------------------------------------------------------

--- a/plugins/power/Makefile.am
+++ b/plugins/power/Makefile.am
@@ -39,6 +39,7 @@ gsd_power_SOURCES =				\
 
 gsd_power_CFLAGS =					\
 	$(PLUGIN_CFLAGS)				\
+	$(XRANDR_REAL_CFLAGS)				\
 	$(POWER_CFLAGS)
 
 gsd_power_CPPFLAGS =					\
@@ -55,6 +56,7 @@ gsd_power_CPPFLAGS =					\
 gsd_power_LDADD =					\
 	$(top_builddir)/plugins/common/libcommon.la	\
 	$(top_builddir)/gnome-settings-daemon/libgsd.la \
+	$(XRANDR_REAL_LIBS)				\
 	$(POWER_LIBS)					\
 	$(LIBM)
 


### PR DESCRIPTION
Linux generally use sysfs for backlight control, but this is not
true for the proprietary nvidia driver, where the only known backlight
control interface is through xrandr.

gnome-settings-daemon already has the right codepath here, but it is
only activated on non-Linux. Activate it for the nvidia driver instead.

This patch can be dropped in future, when the nvidia driver migrates
to offering backlight control in /sys (also needed for wayland).

https://phabricator.endlessm.com/T19517