### PR TITLE
Handle XF86RFKill

### DIFF
--- a/plugins/media-keys/shortcuts-list.h
+++ b/plugins/media-keys/shortcuts-list.h
@@ -110,6 +110,7 @@ static struct {
         { BATTERY_KEY, NULL, N_("Battery Status"), "XF86Battery", GSD_ACTION_MODE_LAUNCHER },
         { RFKILL_KEY, NULL, N_("Toggle Airplane Mode"), "XF86WLAN", GSD_ACTION_MODE_LAUNCHER },
         { RFKILL_KEY, NULL, N_("Toggle Airplane Mode"), "XF86UWB", GSD_ACTION_MODE_LAUNCHER },
+        { RFKILL_KEY, NULL, N_("Toggle Airplane Mode"), "XF86RFKill", GSD_ACTION_MODE_LAUNCHER },
         { BLUETOOTH_RFKILL_KEY, NULL, N_("Toggle Bluetooth"), "XF86Bluetooth", GSD_ACTION_MODE_LAUNCHER }
 };
 

--- a/plugins/rfkill/gsd-rfkill-manager.c
+++ b/plugins/rfkill/gsd-rfkill-manager.c
@@ -76,6 +76,9 @@ struct GsdRfkillManagerPrivate
         GDBusObjectManager      *mm_client;
         gboolean                 wwan_interesting;
 
+        GsdSessionManager       *session;
+        GBinding                *rfkill_input_inhibit_binding;
+
         gchar                   *chassis_type;
 };
 
@@ -522,6 +525,11 @@ on_bus_gotten (GObject               *source_object,
                                                                NULL,
                                                                NULL,
                                                                NULL);
+
+        manager->priv->session = gnome_settings_bus_get_session_proxy ();
+        manager->priv->rfkill_input_inhibit_binding = g_object_bind_property (manager->priv->session, "session-is-active",
+                                                                              manager->priv->rfkill, "rfkill-input-inhibited",
+                                                                              G_BINDING_SYNC_CREATE);
 }
 
 static void
@@ -710,6 +718,8 @@ gsd_rfkill_manager_stop (GsdRfkillManager *manager)
 
         g_clear_pointer (&p->introspection_data, g_dbus_node_info_unref);
         g_clear_object (&p->connection);
+        g_clear_object (&p->rfkill_input_inhibit_binding);
+        g_clear_object (&p->session);
         g_clear_object (&p->rfkill);
         g_clear_pointer (&p->killswitches, g_hash_table_destroy);
         g_clear_pointer (&p->bt_killswitches, g_hash_table_destroy);

--- a/plugins/rfkill/rfkill-glib.c
+++ b/plugins/rfkill/rfkill-glib.c
@@ -493,7 +493,7 @@ cc_rfkill_glib_set_rfkill_input_inhibited (CcRfkillGlib *rfkill,
 		rfkill->noinput_fd = fd;
 	}
 
-	g_object_notify (G_OBJECT (rfkill), "kernel-noinput");
+	g_object_notify (G_OBJECT (rfkill), "rfkill-input-inhibited");
 }
 
 static void

--- a/plugins/rfkill/rfkill-glib.c
+++ b/plugins/rfkill/rfkill-glib.c
@@ -31,6 +31,7 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <string.h>
+#include <sys/ioctl.h>
 
 #include <glib.h>
 #include <gio/gio.h>
@@ -43,6 +44,10 @@ enum {
 	LAST_SIGNAL
 };
 
+enum {
+	PROP_RFKILL_INPUT_INHIBITED = 1
+};
+
 static int signals[LAST_SIGNAL] = { 0 };
 
 struct _CcRfkillGlib {
@@ -51,6 +56,9 @@ struct _CcRfkillGlib {
 	GOutputStream *stream;
 	GIOChannel *channel;
 	guint watch_id;
+
+	/* rfkill-input inhibitor */
+	int noinput_fd;
 
 	/* Pending Bluetooth enablement.
 	 * If (@change_all_timeout_id != 0), then (task != NULL). The converse
@@ -356,6 +364,7 @@ event_cb (GIOChannel   *source,
 static void
 cc_rfkill_glib_init (CcRfkillGlib *rfkill)
 {
+	rfkill->noinput_fd = -1;
 }
 
 int
@@ -433,6 +442,96 @@ cc_rfkill_glib_open (CcRfkillGlib *rfkill)
 	return fd;
 }
 
+#define RFKILL_INPUT_INHIBITED(rfkill) (rfkill->noinput_fd >= 0)
+
+gboolean
+cc_rfkill_glib_get_rfkill_input_inhibited (CcRfkillGlib        *rfkill)
+{
+	g_return_val_if_fail (CC_RFKILL_IS_GLIB (rfkill), FALSE);
+
+	return RFKILL_INPUT_INHIBITED(rfkill);
+}
+
+void
+cc_rfkill_glib_set_rfkill_input_inhibited (CcRfkillGlib *rfkill,
+					   gboolean      inhibit)
+{
+	g_return_if_fail (CC_RFKILL_IS_GLIB (rfkill));
+
+	/* Nothing to do if the states already match. */
+	if (RFKILL_INPUT_INHIBITED(rfkill) == inhibit)
+		return;
+
+	if (!inhibit && RFKILL_INPUT_INHIBITED(rfkill)) {
+		close (rfkill->noinput_fd);
+		rfkill->noinput_fd = -1;
+
+		g_debug ("Closed rfkill noinput FD.");
+	}
+
+	if (inhibit && !RFKILL_INPUT_INHIBITED(rfkill)) {
+		int fd, res;
+		/* Open write only as we don't want to do any IO to it ever. */
+		fd = open ("/dev/rfkill", O_WRONLY);
+		if (fd < 0) {
+			if (errno == EACCES)
+				g_warning ("Could not open RFKILL control device, please verify your installation");
+			else
+				g_debug ("Could not open RFKILL control device: %s", g_strerror (errno));
+			return;
+		}
+
+		res = ioctl (fd, RFKILL_IOCTL_NOINPUT, (long) 0);
+		if (res != 0) {
+			g_warning ("Could not disable kernel handling of RFKILL related keys: %s", g_strerror (errno));
+			close (fd);
+			return;
+		}
+
+		g_debug ("Opened rfkill-input inhibitor.");
+
+		rfkill->noinput_fd = fd;
+	}
+
+	g_object_notify (G_OBJECT (rfkill), "kernel-noinput");
+}
+
+static void
+cc_rfkill_glib_set_property (GObject      *object,
+			 guint	       prop_id,
+			 const GValue *value,
+			 GParamSpec   *pspec)
+{
+	CcRfkillGlib *rfkill = CC_RFKILL_GLIB (object);
+
+	switch (prop_id) {
+	case PROP_RFKILL_INPUT_INHIBITED:
+		cc_rfkill_glib_set_rfkill_input_inhibited (rfkill, g_value_get_boolean (value));
+		break;
+	default:
+		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+		break;
+	}
+}
+
+static void
+cc_rfkill_glib_get_property (GObject    *object,
+			 guint	     prop_id,
+			 GValue	    *value,
+			 GParamSpec *pspec)
+{
+	CcRfkillGlib *rfkill = CC_RFKILL_GLIB (object);
+
+	switch (prop_id) {
+	case PROP_RFKILL_INPUT_INHIBITED:
+		g_value_set_boolean (value, RFKILL_INPUT_INHIBITED(rfkill));
+		break;
+	default:
+		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+		break;
+	}
+}
+
 static void
 cc_rfkill_glib_finalize (GObject *object)
 {
@@ -449,6 +548,11 @@ cc_rfkill_glib_finalize (GObject *object)
 	}
 	g_clear_object (&rfkill->stream);
 
+	if (RFKILL_INPUT_INHIBITED(rfkill)) {
+		close (rfkill->noinput_fd);
+		rfkill->noinput_fd = -1;
+	}
+
 	G_OBJECT_CLASS(cc_rfkill_glib_parent_class)->finalize(object);
 }
 
@@ -457,7 +561,17 @@ cc_rfkill_glib_class_init(CcRfkillGlibClass *klass)
 {
 	GObjectClass *object_class = (GObjectClass *) klass;
 
+	object_class->set_property = cc_rfkill_glib_set_property;
+	object_class->get_property = cc_rfkill_glib_get_property;
 	object_class->finalize = cc_rfkill_glib_finalize;
+
+	g_object_class_install_property (object_class,
+					 PROP_RFKILL_INPUT_INHIBITED,
+					 g_param_spec_boolean ("rfkill-input-inhibited",
+							       "Rfkill input inhibited",
+							       "Whether to prevent the kernel from handling RFKILL related key events.",
+							       FALSE,
+							       G_PARAM_READWRITE));
 
 	signals[CHANGED] =
 		g_signal_new ("changed",

--- a/plugins/rfkill/rfkill-glib.h
+++ b/plugins/rfkill/rfkill-glib.h
@@ -36,6 +36,10 @@ G_DECLARE_FINAL_TYPE (CcRfkillGlib, cc_rfkill_glib, CC_RFKILL, GLIB, GObject)
 CcRfkillGlib *cc_rfkill_glib_new               (void);
 int           cc_rfkill_glib_open              (CcRfkillGlib *rfkill);
 
+gboolean      cc_rfkill_glib_get_rfkill_input_inhibited (CcRfkillGlib        *rfkill);
+void          cc_rfkill_glib_set_rfkill_input_inhibited (CcRfkillGlib        *rfkill,
+							 gboolean             noinput);
+
 void          cc_rfkill_glib_send_change_all_event        (CcRfkillGlib        *rfkill,
 							   guint                rfkill_type,
 							   gboolean             enable,


### PR DESCRIPTION
This series adds support the the XF86RFKill keysym and inhibits the rfkill-input kernel handlers to avoid conflicts with userspace handling of KEY_RFKILL.

https://phabricator.endlessm.com/T20508