### PR TITLE
xsettings: Update signature of org.gnome.Mutter.DisplayConfig.GetCurrentState

### DIFF
--- a/plugins/xsettings/gsd-xsettings-manager.c
+++ b/plugins/xsettings/gsd-xsettings-manager.c
@@ -535,7 +535,7 @@ is_layout_mode_logical (GVariantIter *properties)
         return layout_mode == DISPLAY_LAYOUT_MODE_LOGICAL;
 }
 
-#define MODE_FORMAT "(siiddada{sv})"
+#define MODE_FORMAT "(ssiiddada{sv})"
 #define MODES_FORMAT "a" MODE_FORMAT
 
 #define MONITOR_SPEC_FORMAT "(ssss)"


### PR DESCRIPTION
We have introduced an additional string to the monitor mode to expose a
human-friendly name for monitor modes (e.g. "1920x1080"), so we need to
update the D-Bus signature here for consistency, so that the expected
and the actual signatures match.

https://phabricator.endlessm.com/T20655