### PR TITLE
gsd: Control panel and function key should not set brightness to 0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "plugins/media-keys/gvc"]
 	path = plugins/media-keys/gvc
-	url = git://git.gnome.org/libgnome-volume-control
+	url = https://gitlab.gnome.org/GNOME/libgnome-volume-control.git

--- a/plugins/power/gpm-common.c
+++ b/plugins/power/gpm-common.c
@@ -732,6 +732,8 @@ backlight_set_percentage (GnomeRRScreen *rr_screen,
                 GnomeRROutput *output;
                 output = get_primary_output (rr_screen);
                 if (output != NULL) {
+                        /* For not as dark as 0 */
+                        *value = MAX (*value, 1);
                         if (!gnome_rr_output_set_backlight (output, *value, error))
                                 return ret;
                         *value = gnome_rr_output_get_backlight (output);
@@ -742,7 +744,8 @@ backlight_set_percentage (GnomeRRScreen *rr_screen,
         max = backlight_helper_get_value (BACKLIGHT_HELPER_GET_MAX, error);
         if (max < 0)
                 return ret;
-        discrete = PERCENTAGE_TO_ABS (0, max, *value);
+        /* For not as dark as 0 */
+        discrete = PERCENTAGE_TO_ABS (0, max, MAX(*value, 1));
         ret = backlight_helper_set_value (discrete, error);
         if (ret)
                 *value = ABS_TO_PERCENTAGE (0, max, discrete);
@@ -834,7 +837,7 @@ backlight_step_down (GnomeRRScreen *rr_screen, GError **error)
                         if (now < 0)
                                 return percentage_value;
                         step = MAX (gnome_rr_output_get_min_backlight_step (output), BRIGHTNESS_STEP_AMOUNT (max + 1));
-                        discrete = MAX (now - step, 0);
+                        discrete = MAX (now - step, PERCENTAGE_TO_ABS (0, max, 1));
                         ret = gnome_rr_output_set_backlight (output,
                                                              discrete,
                                                              error);
@@ -850,7 +853,7 @@ backlight_step_down (GnomeRRScreen *rr_screen, GError **error)
         if (max < 0)
                 return percentage_value;
         step = BRIGHTNESS_STEP_AMOUNT (max + 1);
-        discrete = MAX (now - step, 0);
+        discrete = MAX (now - step, PERCENTAGE_TO_ABS (0, max, 1));
         ret = backlight_helper_set_value (discrete, error);
         if (ret)
                 percentage_value = ABS_TO_PERCENTAGE (0, max, discrete);


### PR DESCRIPTION
The user could slide the brightness on the control panel or press the
function key to make the screen brightness to 0.
However, If the user does not know about the keyboard buttons, he/she
will have a hard time turning the display back from the control panel if
the display is too dim or completely off.
For example, systems like ASUS UX550GE's brightness is in the range from
1 to 120000.  The brightness level 1 has the backlight level which is so
dim and it's also practically unusable.

This patch makes it limiting to 1% brightness as the lower bound avoids
that usability issue.

Signed-off-by: Jian-Hong Pan <jian-hong@endlessm.com>
(cherry picked from commit 1538fd045ac88e5916bdc32f60331331b744a39e)
Signed-off-by: Robert McQueen <rob@endlessm.com>

https://phabricator.endlessm.com/T4839