### PR TITLE
power: Disable turning off display for suspending

### DIFF
--- a/plugins/power/gsd-power-manager.c
+++ b/plugins/power/gsd-power-manager.c
@@ -2435,7 +2435,7 @@ on_randr_event (GnomeRRScreen *screen, gpointer user_data)
 static void
 handle_suspend_actions (GsdPowerManager *manager)
 {
-        backlight_disable (manager);
+        manager->priv->screensaver_active = TRUE;
         uninhibit_suspend (manager);
 }
 


### PR DESCRIPTION
The execution of turning off the display for suspending may be postponed
to after system resumes on Acer Veriton Z4660G series AIOs.

Disabling turning off the backlight actions during the time slot between
suspend and resume fixes the issue.

https://phabricator.endlessm.com/T24332

Signed-off-by: Jian-Hong Pan <jian-hong@endlessm.com>