### PR TITLE
plugins: Add desktop-entry hints to notifications

### DIFF
--- a/plugins/a11y-keyboard/gsd-a11y-keyboard-manager.c
+++ b/plugins/a11y-keyboard/gsd-a11y-keyboard-manager.c
@@ -408,6 +408,7 @@ ax_slowkeys_warning_post_bubble (GsdA11yKeyboardManager *manager,
                                                                message,
                                                                "preferences-desktop-accessibility-symbolic");
         notify_notification_set_app_name (manager->priv->notification, _("Universal Access"));
+        notify_notification_set_hint_string (manager->priv->notification, "desktop-entry", "gnome-universal-access-panel");
         notify_notification_set_timeout (manager->priv->notification, 0);
         notify_notification_set_urgency (manager->priv->notification, NOTIFY_URGENCY_CRITICAL);
 

--- a/plugins/color/gsd-color-calibrate.c
+++ b/plugins/color/gsd-color-calibrate.c
@@ -137,6 +137,7 @@ gcm_session_notify_recalibrate (GsdColorCalibrate *calibrate,
         notify_notification_set_timeout (notification, GCM_SESSION_NOTIFY_TIMEOUT);
         notify_notification_set_urgency (notification, NOTIFY_URGENCY_LOW);
         notify_notification_set_app_name (notification, _("Color"));
+        notify_notification_set_hint_string (notification, "desktop-entry", "gnome-color-panel");
 
         notify_notification_add_action (notification,
                                         "recalibrate",

--- a/plugins/datetime/gsd-datetime-manager.c
+++ b/plugins/datetime/gsd-datetime-manager.c
@@ -116,6 +116,7 @@ timezone_changed_cb (GsdTimezoneMonitor *timezone_monitor,
         g_free (notification_summary);
 
         notify_notification_set_app_name (self->priv->notification, _("Date & Time Settings"));
+        notify_notification_set_hint_string (self->priv->notification, "desktop-entry", "gnome-datetime-panel");
         notify_notification_set_urgency (self->priv->notification, NOTIFY_URGENCY_NORMAL);
         notify_notification_set_timeout (self->priv->notification, NOTIFY_EXPIRES_NEVER);
 

--- a/plugins/housekeeping/gsd-disk-space.c
+++ b/plugins/housekeeping/gsd-disk-space.c
@@ -578,6 +578,7 @@ ldsm_notify (const char *summary,
         notify_notification_set_hint (notification, "transient", g_variant_new_boolean (TRUE));
         notify_notification_set_urgency (notification, NOTIFY_URGENCY_CRITICAL);
         notify_notification_set_timeout (notification, NOTIFY_EXPIRES_DEFAULT);
+        notify_notification_set_hint_string (notification, "desktop-entry", "org.gnome.baobab");
 
         program = g_find_program_in_path (DISK_SPACE_ANALYZER);
         has_disk_analyzer = (program != NULL);

--- a/plugins/power/gsd-power-manager.c
+++ b/plugins/power/gsd-power-manager.c
@@ -322,6 +322,7 @@ create_notification (const char *summary,
         notification = notify_notification_new (summary, body, icon_name);
         /* TRANSLATORS: this is the notification application name */
         notify_notification_set_app_name (notification, _("Power"));
+        notify_notification_set_hint_string (notification, "desktop-entry", "gnome-power-panel");
         notify_notification_set_urgency (notification,
                                          NOTIFY_URGENCY_CRITICAL);
         *weak_pointer_location = notification;

--- a/plugins/print-notifications/gsd-print-notifications-manager.c
+++ b/plugins/print-notifications/gsd-print-notifications-manager.c
@@ -272,6 +272,7 @@ show_notification (gpointer user_data)
                                       "resident",
                                       g_variant_new_boolean (TRUE));
         notify_notification_set_timeout (notification, REASON_TIMEOUT);
+        notify_notification_set_hint_string (notification, "desktop-entry", "gnome-printers-panel");
 
         reason_data = g_new0 (ReasonData, 1);
         reason_data->printer_name = g_strdup (data->printer_name);
@@ -746,6 +747,7 @@ process_cups_notification (GsdPrintNotificationsManager *manager,
                                                                                                 second_row,
                                                                                                 "printer-symbolic");
                                                         notify_notification_set_app_name (notification, _("Printers"));
+                                                        notify_notification_set_hint_string (notification, "desktop-entry", "gnome-printers-panel");
                                                         notify_notification_set_hint (notification,
                                                                                       "resident",
                                                                                       g_variant_new_boolean (TRUE));
@@ -836,6 +838,7 @@ process_cups_notification (GsdPrintNotificationsManager *manager,
                                                                                 second_row,
                                                                                 "printer-symbolic");
                                         notify_notification_set_app_name (notification, _("Printers"));
+                                        notify_notification_set_hint_string (notification, "desktop-entry", "gnome-printers-panel");
                                         notify_notification_set_hint (notification,
                                                                       "resident",
                                                                       g_variant_new_boolean (TRUE));
@@ -879,6 +882,7 @@ process_cups_notification (GsdPrintNotificationsManager *manager,
                                                         secondary_text,
                                                         "printer-symbolic");
                 notify_notification_set_app_name (notification, _("Printers"));
+                notify_notification_set_hint_string (notification, "desktop-entry", "gnome-printers-panel");
                 notify_notification_set_hint (notification, "transient", g_variant_new_boolean (TRUE));
                 notify_notification_show (notification, NULL);
                 g_object_unref (notification);

--- a/plugins/print-notifications/gsd-printer.c
+++ b/plugins/print-notifications/gsd-printer.c
@@ -1029,6 +1029,7 @@ handle_method_call (GDBusConnection       *connection,
                                                         secondary_text,
                                                         "printer-symbolic");
                 notify_notification_set_app_name (notification, _("Printers"));
+                notify_notification_set_hint_string (notification, "desktop-entry", "gnome-printers-panel");
                 notify_notification_set_hint (notification, "transient", g_variant_new_boolean (TRUE));
 
                 notify_notification_show (notification, NULL);


### PR DESCRIPTION
This allows the notifications to be tied back to an application (or, in
this case, control panel capplet) which is related to it; and allows the
user to specify per-app preferences for how the notifications are to be
displayed.

(Backport to EOS: Fix merge conflicts in plugins/print-notifications;
support additional notification in plugins/a11y-keyboard.)

https://wiki.gnome.org/Initiatives/GnomeGoals/NotificationSource

Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T20990