### PR TITLE
media-keys: Add mapping for Ctrl + Super + TouchpadToggle

### DIFF
--- a/plugins/media-keys/shortcuts-list.h
+++ b/plugins/media-keys/shortcuts-list.h
@@ -43,6 +43,7 @@ static struct {
         ShellActionMode modes;
 } media_keys[] = {
         { TOUCHPAD_KEY, NULL, N_("Touchpad toggle") ,"XF86TouchpadToggle", SHELL_ACTION_MODE_ALL },
+        { TOUCHPAD_KEY, NULL, N_("Touchpad toggle") ,"<Ctrl><Super>XF86TouchpadToggle", SHELL_ACTION_MODE_ALL },
         { TOUCHPAD_ON_KEY, NULL, N_("Touchpad On"), "XF86TouchpadOn", SHELL_ACTION_MODE_ALL },
         { TOUCHPAD_OFF_KEY, NULL, N_("Touchpad Off"), "XF86TouchpadOff", SHELL_ACTION_MODE_ALL },
         { MUTE_KEY, "volume-mute", NULL, NULL, SHELL_ACTION_MODE_ALL },


### PR DESCRIPTION
Some budget laptops send Ctrl + Super + custom-scancode when their
touchpad-toggle hotkey (Fn + something) gets pressed.

hwdb will map the custom-scancode to TouchpadToggle, but we need to deal
with the Ctrl + Super in the media-keys plugin, add a mapping for this.

https://bugzilla.gnome.org/show_bug.cgi?id=793610