### PR TITLE
led-breathe: only build on platforms where the header is available

### DIFF
--- a/plugins/power/meson.build
+++ b/plugins/power/meson.build
@@ -41,14 +41,16 @@ gsd_power = executable(
   install_dir: gsd_libexecdir
 )
 
-led_breathe = executable(
-  'led-breathe',
-  files('led-breathe.c'),
-  install: true,
-  install_mode: ['rwsr-xr-x', 'root'],
-  install_rpath: gsd_pkglibdir,
-  install_dir: gsd_libexecdir,
-)
+if meson.get_compiler('c').has_header('sys/io.h')
+  led_breathe = executable(
+    'led-breathe',
+    files('led-breathe.c'),
+    install: true,
+    install_mode: ['rwsr-xr-x', 'root'],
+    install_rpath: gsd_pkglibdir,
+    install_dir: gsd_libexecdir,
+  )
+endif
 
 sources = files('gsd-power-enums-update.c')
 


### PR DESCRIPTION
led-breathe uses x86- and armhf- specific hardware access via io.h.

This is not supported on arm64, where the sys/io.h header is
unavailable.

Avoids compile failure on arm64:
[  352s] ../plugins/power/led-breathe.c:13:10: fatal error: sys/io.h: No such file or directory
[  352s]  #include <sys/io.h>
[  352s]           ^~~~~~~~~~
[  352s] compilation terminated.

https://phabricator.endlessm.com/T24973