### PR TITLE
power: lock screen in handle_suspend_actions

### DIFF
--- a/plugins/power/gsd-power-manager.c
+++ b/plugins/power/gsd-power-manager.c
@@ -2381,7 +2381,8 @@ on_randr_event (GnomeRRScreen *screen, gpointer user_data)
 static void
 handle_suspend_actions (GsdPowerManager *manager)
 {
-        backlight_disable (manager);
+	/* Lock screen instead of only disabling backlight */
+	lock_screensaver (manager);
         uninhibit_suspend (manager);
 }
 


### PR DESCRIPTION
When try to suspend system by GUI or terminal on the laptops like ASUS
E402YA, system blanks screen, but then also flashes the locked screen
for a second. According to the gdb log, we noticed the
backlight_disable() is invoked twice for suspending.

Thread 1 "gsd-power" hit Breakpoint 1, backlight_disable (manager=manager@entry=0x560dda4a0150)
    at ../plugins/power/gsd-power-manager.c:1055
1055	../plugins/power/gsd-power-manager.c: No such file or directory.
(gdb) bt
 #0  backlight_disable (manager=manager@entry=0x560dda4a0150) at ../plugins/power/gsd-power-manager.c:1055
 #1  0x0000560dd84d9f1c in handle_suspend_actions (manager=0x560dda4a0150) at ../plugins/power/gsd-power-manager.c:2412
 #2  logind_proxy_signal_cb (proxy=<optimized out>, sender_name=<optimized out>, signal_name=0x560dda5abe40 "PrepareForSleep",
     parameters=0x7f11c4040210, user_data=<optimized out>) at ../plugins/power/gsd-power-manager.c:2412
 #3  0x00007f11deef98ee in ffi_call_unix64 () from /lib/x86_64-linux-gnu/libffi.so.6
 #4  0x00007f11deef92bf in ffi_call () from /lib/x86_64-linux-gnu/libffi.so.6
 #5  0x00007f11e0f7c682 in g_cclosure_marshal_generic () from /lib/x86_64-linux-gnu/libgobject-2.0.so.0
 #6  0x00007f11e0f7be8d in g_closure_invoke () from /lib/x86_64-linux-gnu/libgobject-2.0.so.0
 #7  0x00007f11e0f8f555 in ?? () from /lib/x86_64-linux-gnu/libgobject-2.0.so.0
 #8  0x00007f11e0f984ae in g_signal_emit_valist () from /lib/x86_64-linux-gnu/libgobject-2.0.so.0
 #9  0x00007f11e0f98b6f in g_signal_emit () from /lib/x86_64-linux-gnu/libgobject-2.0.so.0
 #10 0x00007f11e10cdf28 in ?? () from /lib/x86_64-linux-gnu/libgio-2.0.so.0
 #11 0x00007f11e10bcda4 in ?? () from /lib/x86_64-linux-gnu/libgio-2.0.so.0
 #12 0x00007f11e0e95958 in g_main_context_dispatch () from /lib/x86_64-linux-gnu/libglib-2.0.so.0
 #13 0x00007f11e0e95d48 in ?? () from /lib/x86_64-linux-gnu/libglib-2.0.so.0
 #14 0x00007f11e0e96042 in g_main_loop_run () from /lib/x86_64-linux-gnu/libglib-2.0.so.0
 #15 0x00007f11e14c5ba5 in gtk_main () from /lib/x86_64-linux-gnu/libgtk-3.so.0
 #16 0x0000560dd84d4071 in main (argc=<optimized out>, argv=<optimized out>) at ../plugins/common/daemon-skeleton-gtk.h:273
(gdb) c
Continuing.
[Detaching after fork from child process 7214]

Thread 1 "gsd-power" hit Breakpoint 1, backlight_disable (manager=manager@entry=0x560dda4a0150)
    at ../plugins/power/gsd-power-manager.c:1055
1055	in ../plugins/power/gsd-power-manager.c
(gdb) bt
 #0  backlight_disable (manager=manager@entry=0x560dda4a0150) at ../plugins/power/gsd-power-manager.c:1055
 #1  0x0000560dd84d7be5 in idle_set_mode (manager=manager@entry=0x560dda4a0150, mode=mode@entry=GSD_POWER_IDLE_MODE_BLANK)
    at ../plugins/power/gsd-power-manager.c:1573
 #2  0x0000560dd84d9e18 in handle_screensaver_active (parameters=0x7f11c4040390, manager=0x560dda4a0150)
    at ../plugins/power/gsd-power-manager.c:1965
 #3  screensaver_signal_cb (proxy=<optimized out>, sender_name=<optimized out>, signal_name=<optimized out>,
    parameters=0x7f11c4040390, user_data=0x560dda4a0150) at ../plugins/power/gsd-power-manager.c:1983
 #4  0x00007f11deef98ee in ffi_call_unix64 () from /lib/x86_64-linux-gnu/libffi.so.6
 #5  0x00007f11deef92bf in ffi_call () from /lib/x86_64-linux-gnu/libffi.so.6
 #6  0x00007f11e0f7c682 in g_cclosure_marshal_generic () from /lib/x86_64-linux-gnu/libgobject-2.0.so.0
 #7  0x00007f11e0f7be8d in g_closure_invoke () from /lib/x86_64-linux-gnu/libgobject-2.0.so.0
 #8  0x00007f11e0f8f555 in ?? () from /lib/x86_64-linux-gnu/libgobject-2.0.so.0
 #9  0x00007f11e0f984ae in g_signal_emit_valist () from /lib/x86_64-linux-gnu/libgobject-2.0.so.0
 #10 0x00007f11e0f98b6f in g_signal_emit () from /lib/x86_64-linux-gnu/libgobject-2.0.so.0
 #11 0x00007f11e10cdf28 in ?? () from /lib/x86_64-linux-gnu/libgio-2.0.so.0
 #12 0x00007f11e10bcda4 in ?? () from /lib/x86_64-linux-gnu/libgio-2.0.so.0
 #13 0x00007f11e0e95958 in g_main_context_dispatch () from /lib/x86_64-linux-gnu/libglib-2.0.so.0
 #14 0x00007f11e0e95d48 in ?? () from /lib/x86_64-linux-gnu/libglib-2.0.so.0
 #15 0x00007f11e0e96042 in g_main_loop_run () from /lib/x86_64-linux-gnu/libglib-2.0.so.0
 #16 0x00007f11e14c5ba5 in gtk_main () from /lib/x86_64-linux-gnu/libgtk-3.so.0
 #17 0x0000560dd84d4071 in main (argc=<optimized out>, argv=<optimized out>) at ../plugins/common/daemon-skeleton-gtk.h:273
(gdb) c
Continuing.

The 1st comes from handle_suspend_actions(), and the 2nd comes from
idle_set_mode() which is invoked by handle_screensaver_active().

To treat the screen behavior better, this patch replaces the
backlight_disable() with lock_screensaver() in handle_suspend_actions().
Even the backlight is turned on again during suspending, it only shows
black screen.  Mitigate #416

https://phabricator.endlessm.com/T26050