### PR TITLE
media-keys: Divide keyboard brightness value by 100

### DIFF
--- a/plugins/media-keys/gsd-media-keys-manager.c
+++ b/plugins/media-keys/gsd-media-keys-manager.c
@@ -3733,7 +3733,7 @@ power_keyboard_proxy_signal_cb (GDBusProxy  *proxy,
         if (g_strcmp0 (source, "internal") != 0)
                 return;
 
-        show_osd (manager, "keyboard-brightness-symbolic", NULL, brightness, NULL);
+        show_osd (manager, "keyboard-brightness-symbolic", NULL, (double) brightness / 100.0, NULL);
 }
 
 static void


### PR DESCRIPTION
Since the OSD in the shell changed [1] to using float values from 0.0 to
1.0, send a double instead of a percentage via DBus.

[1] https://gitlab.gnome.org/GNOME/gnome-shell/merge_requests/385

https://phabricator.endlessm.com/T28848