### PR TITLE
debian: Bump version to 3.36.0-0endless1

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+gnome-settings-daemon (3.36.0-0endless1) master; urgency=medium
+
+  * Bump version for source-code-only rebase from 3.35.92 to 3.36.0
+
+ -- Philip Withnall <withnall@endlessm.com>  Tue, 10 Mar 2020 12:28:00 +0000
+
 gnome-settings-daemon (3.35.92-0endless1) master; urgency=medium
 
   * patches/debian/meson.build-Lower-polkit-requirement.patch: Drop, not


### PR DESCRIPTION
Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T28835

---

Code changes in #67. **This should be pushed via the command line rather than GitHub.**